### PR TITLE
feat: Implement agent selection UI and basic chat backend

### DIFF
--- a/app/TradingAgents/ui_backend/api_server.py
+++ b/app/TradingAgents/ui_backend/api_server.py
@@ -6,6 +6,13 @@ import uuid
 app = Flask(__name__)
 CORS(app)
 
+# Define the list of agent names
+AGENT_NAMES = [
+    "Market Analyst", "Social Analyst", "News Analyst", "Fundamentals Analyst",
+    "Bull Researcher", "Bear Researcher", "Research Manager", "Trader",
+    "Risky Analyst", "Neutral Analyst", "Safe Analyst", "Portfolio Manager"
+]
+
 # In-memory storage for trades only
 mock_pending_trades_store: Dict[str, Dict[str, Any]] = {}
 
@@ -75,6 +82,31 @@ def initialize_mock_trades():
     print(f"Mock trades initialized. Count: {len(mock_pending_trades_store)}")
 
 initialize_mock_trades()
+
+@app.route('/api/agents', methods=['GET'])
+def get_agents():
+    """Returns the list of available agent names."""
+    return jsonify(AGENT_NAMES)
+
+@app.route('/api/chat', methods=['POST'])
+def chat():
+    """Handles chat messages to agents or StroudAI."""
+    data = request.get_json()
+    if not data or 'message' not in data:
+        return jsonify({"error": "Missing message in request"}), 400
+
+    message = data['message']
+    agent_id = data.get('agent_id')
+
+    if agent_id:
+        if agent_id in AGENT_NAMES:
+            response_text = f"Response from {agent_id}: You said '{message}'"
+        else:
+            return jsonify({"error": f"Agent {agent_id} not found"}), 404
+    else:
+        response_text = f"Response from StroudAI: You said '{message}'"
+
+    return jsonify({"sender": "ai", "text": response_text})
 
 @app.route('/api/pending_trades', methods=['GET'])
 def pending_trades():

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useRef } from "react"
+import { useState, useRef, useEffect } from "react"
 import Header from "@/components/header"
 import LiveFeedPanel from "@/components/live-feed-panel"
 import MetaAgentPanel from "@/components/meta-agent-panel"
@@ -18,7 +18,27 @@ export default function Dashboard() {
   const [messages, setMessages] = useState([
     { sender: "ai", text: "Hi! I am Stroud AI. How can I help you trade today?" },
   ])
+  const [agentsList, setAgentsList] = useState<string[]>([])
+  const [selectedAgent, setSelectedAgent] = useState<string | null>(null)
   const chatEndRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const fetchAgents = async () => {
+      try {
+        const response = await fetch("http://127.0.0.1:5000/api/agents")
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`)
+        }
+        const data = await response.json()
+        setAgentsList(data)
+      } catch (error) {
+        console.error("Failed to fetch agents:", error)
+        // Optionally, set an error state here to display to the user
+      }
+    }
+
+    fetchAgents()
+  }, [])
 
   const toggleMode = () => {
     setMode(mode === "Manual" ? "Auto" : "Manual")
@@ -51,15 +71,45 @@ export default function Dashboard() {
     setSelectedTrade(null)
   }
 
-  const handleSendMessage = (msg: string) => {
-    if (!msg.trim()) return
-    setMessages((prev) => [
-      ...prev,
-      { sender: "user", text: msg },
-      { sender: "ai", text: `Echo: ${msg}` }, // Replace with real LLM call
-    ])
-    setTimeout(() => chatEndRef.current?.scrollIntoView({ behavior: "smooth" }), 100)
-  }
+  const handleSendMessage = async (msg: string) => {
+    if (!msg.trim()) return;
+    const userMessage = { sender: "user", text: msg };
+    setMessages((prev) => [...prev, userMessage]);
+
+    // Optimistically scroll immediately for user message
+    setTimeout(() => chatEndRef.current?.scrollIntoView({ behavior: "smooth" }), 0);
+
+    try {
+      const response = await fetch("http://127.0.0.1:5000/api/chat", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          message: msg,
+          agent_id: selectedAgent, // Pass null if no agent is selected (StroudAI general)
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const aiResponse = await response.json();
+      setMessages((prev) => [...prev, aiResponse]);
+    } catch (error) {
+      console.error("Failed to send message or get response:", error);
+      setMessages((prev) => [
+        ...prev,
+        {
+          sender: "ai",
+          text: "Sorry, I couldn't connect to the server. Please try again.",
+        },
+      ]);
+    }
+    // Scroll after AI response is added
+    setTimeout(() => chatEndRef.current?.scrollIntoView({ behavior: "smooth" }), 100);
+  };
 
   return (
     <div className="flex flex-col h-screen bg-black text-gray-100">
@@ -77,15 +127,40 @@ export default function Dashboard() {
             />
           </div>
           <div className="mt-auto w-full">
+            {/* Agent Selection UI */}
+            <div className="bg-zinc-950 p-2 md:p-3 border-t border-b border-zinc-800">
+              <div className="flex items-center gap-2 overflow-x-auto pb-2">
+                <button
+                  onClick={() => setSelectedAgent(null)}
+                  className={`px-3 py-1.5 text-xs md:text-sm rounded-lg whitespace-nowrap focus:outline-none transition-colors
+                    ${selectedAgent === null ? "bg-firebrick text-white" : "bg-zinc-800 hover:bg-zinc-700 text-gray-300"}`}
+                >
+                  StroudAI (General)
+                </button>
+                {agentsList.map((agentName) => (
+                  <button
+                    key={agentName}
+                    onClick={() => setSelectedAgent(agentName)}
+                    className={`px-3 py-1.5 text-xs md:text-sm rounded-lg whitespace-nowrap focus:outline-none transition-colors
+                      ${selectedAgent === agentName ? "bg-firebrick text-white" : "bg-zinc-800 hover:bg-zinc-700 text-gray-300"}`}
+                  >
+                    {agentName}
+                  </button>
+                ))}
+              </div>
+            </div>
+            {/* Chat Messages Area */}
             <div className="bg-zinc-900 border-t border-zinc-800 px-2 md:px-4 pt-2 md:pt-4 pb-1.5 md:pb-2 flex flex-col w-full"
               style={{ minHeight: '160px', maxHeight: '32vh' }}>
-              <ScrollArea className="flex-1 overflow-y-auto pr-1 md:pr-2" style={{ maxHeight: '22vh' }}>
+              <ScrollArea className="flex-1 overflow-y-auto pr-1 md:pr-2" style={{ maxHeight: 'calc(32vh - 70px)' }}> {/* Adjusted maxHeight */}
                 <div className="flex flex-col gap-2 md:gap-3">
                   {messages.map((msg, i) => (
                     <div key={i} className={`flex ${msg.sender === "user" ? "justify-end" : "justify-start"}`}>
                       {msg.sender === "ai" && (
                         <div className="mr-1 md:mr-2 flex items-end">
-                          <div className="w-7 h-7 md:w-8 md:h-8 rounded-full bg-firebrick flex items-center justify-center text-white font-bold text-base md:text-lg">S</div>
+                          <div className={`w-7 h-7 md:w-8 md:h-8 rounded-full flex items-center justify-center text-white font-bold text-base md:text-lg ${selectedAgent && msg.sender === 'ai' ? 'bg-blue-600' : 'bg-firebrick'}`}>
+                            {selectedAgent && msg.sender === 'ai' ? selectedAgent.substring(0, 1) : 'S'}
+                          </div>
                         </div>
                       )}
                       <div className={`rounded-2xl px-3 md:px-4 py-1.5 md:py-2 max-w-[85vw] md:max-w-[70%] text-xs md:text-sm shadow-md ${msg.sender === "user" ? "bg-firebrick text-white" : "bg-zinc-800 text-gray-100"}`}>{msg.text}</div>


### PR DESCRIPTION
This commit introduces changes to enable you to select a specific trading agent to interact with via the chat interface.

Key changes:

-   **Backend (`api_server.py`):**
    -   Added an `/api/agents` endpoint that returns a list of predefined trading agent names.
    -   Added an `/api/chat` endpoint that accepts your message and an optional `agent_id`. It currently returns a simulated response indicating which agent (or general AI) is replying.

-   **Frontend (`dashboard.tsx`):**
    -   Fetches the list of available agents from the `/api/agents` endpoint on component mount.
    -   Displays agent selection buttons in the UI, allowing you to choose an agent or a general "StroudAI" chat.
    -   The `handleSendMessage` function now includes the `selectedAgent` ID in the payload when sending a message to the `/api/chat` endpoint.
    -   The chat message display has been updated to show the initial of the selected agent in the avatar, providing a visual cue for who is responding.

These changes lay the groundwork for more sophisticated agent-based chat interactions by establishing the necessary UI elements and API communication flow. Further work will involve integrating actual LLM responses and more complex agent interaction logic in the backend.